### PR TITLE
let the links to other repos open in a new tab instead of in current one

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -34,7 +34,7 @@ var mainField = function($, type) {
     if ($main.length > 0) {
       var entryFile = utils.stripQuotes($main);
       if (entryFile) {
-        $main.wrap('<a class="github-linker" href="' + entryFile + '">');
+        $main.wrap('<a class="github-linker" target=_blank href="' + entryFile + '">');
       }
     }
   }
@@ -78,7 +78,7 @@ var dependencieField = function($, type) {
       link = linkBuilder(type, name, version);
 
       if (link) {
-        $item = $item.wrap('<a class="github-linker" href="' + link + '">').parent();
+        $item = $item.wrap('<a class="github-linker" target=_blank href="' + link + '">').parent();
       } else {
         $item.addClass('tooltipped tooltipped-e').attr('aria-label', SORRY);
       }

--- a/lib/require.js
+++ b/lib/require.js
@@ -114,7 +114,7 @@ var init = function($, url, cb) {
         resolveLink = true;
         $item = $item.wrap('<a class="github-linker" data-href="' + link + '">').parent();
       } else {
-        $item = $item.wrap('<a class="github-linker" href="' + link + '">').parent();
+        $item = $item.wrap('<a class="github-linker" target=_blank href="' + link + '">').parent();
       }
     } else {
       $item.addClass('tooltipped tooltipped-e').attr('aria-label', SORRY);


### PR DESCRIPTION
When user is browsing a repo and find some other interesting repos, they may be glad to open those repos in a new tab instead of replacing current one, I guess.
It is possible to do this with 'right click -> open in a new tab', but by just simple click is more handy.
