### PR TITLE
add links to 'directories' field of package.json and 'bin' field

### DIFF
--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -40,6 +40,45 @@ var mainField = function($, type) {
   }
 };
 
+var binField = function($, type) {
+  if (type === 'npm') {
+    var $bin = $('span.nt').filter(function() {
+      return $(this).text().replace(/"|'/g, '') === 'bin';
+    }).next().next('[class^="s"]');
+
+    if ($bin && $bin.length > 0) {
+      var entryFile = utils.stripQuotes($bin);
+      if (entryFile) {
+        $bin.wrap('<a class="github-linker" href="' + entryFile + '">');
+      }
+    }
+  }
+};
+
+var directoriesField = function($) {
+  var $dirname, $dir;
+  var $directories = $('.nt').filter(function(){
+    return $(this).text().replace(/"|'/g, '') === 'directories';
+  });
+
+  if ($directories && $directories.length > 0) {
+    $dirname = $directories.closest('tr').next();
+
+    while ($dirname) {
+      $dir = $dirname.find('.nt').next().next('[class^="s"]');
+      if (!$dir || !$dir.length) {
+        return;
+      }
+      var entryFile = utils.stripQuotes($dir);
+      if (entryFile) {
+        $dir.wrap('<a class="github-linker" href="' + entryFile + '">');
+      }
+
+      $dirname = $dirname.next();
+    }
+  }
+};
+
 var dependencieField = function($, type) {
   var $root, $row, $item, $version, name, version, link;
   var selectors = [];
@@ -99,8 +138,13 @@ var dependencieField = function($, type) {
 var init = function($, url, cb) {
 
   var type = getType(url);
+  if (type === 'npm') {
+    directoriesField($);
+  }
   var result = dependencieField($, type);
+  // put them below dependencieField to avoid conflict
   mainField($, type);
+  binField($, type);
 
   cb(null, result);
 };

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -5,6 +5,11 @@
     "homepage": "https://github.com/stefanbuck/playground-repo",
     "bugs": "https://github.com/stefanbuck/playground-repo/issues",
     "license": "MIT",
+    "directories": {
+      "main": "./main",
+      "bin": "./bin"
+    },
+    "bin": "./index.js",
     "main": "index.js",
     "author": {
         "name": "Stefan Buck",

--- a/test/fixtures/package.json.html
+++ b/test/fixtures/package.json.html
@@ -1,12 +1,16 @@
+
+
+
+
 <!DOCTYPE html>
 <html lang="en" class="">
   <head prefix="og: http://ogp.me/ns# fb: http://ogp.me/ns/fb# object: http://ogp.me/ns/object# article: http://ogp.me/ns/article# profile: http://ogp.me/ns/profile#">
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Language" content="en">
-
-
-    <title>github-linker-core/package.json at master · stefanbuck/github-linker-core · GitHub</title>
+    
+    
+    <title>test/package.json at c01ae7e78a4747302782cb58238797ef257fa617 · spacewander/test</title>
     <link rel="search" type="application/opensearchdescription+xml" href="/opensearch.xml" title="GitHub">
     <link rel="fluid-icon" href="https://github.com/fluidicon.png" title="GitHub">
     <link rel="apple-touch-icon" sizes="57x57" href="/apple-touch-icon-114.png">
@@ -15,71 +19,68 @@
     <link rel="apple-touch-icon" sizes="144x144" href="/apple-touch-icon-144.png">
     <meta property="fb:app_id" content="1401488693436528">
 
-      <meta content="@github" name="twitter:site" /><meta content="summary" name="twitter:card" /><meta content="stefanbuck/github-linker-core" name="twitter:title" /><meta content="github-linker-core - The GitHub Linker core" name="twitter:description" /><meta content="https://avatars2.githubusercontent.com/u/1393946?v=2&amp;s=400" name="twitter:image:src" />
-<meta content="GitHub" property="og:site_name" /><meta content="object" property="og:type" /><meta content="https://avatars2.githubusercontent.com/u/1393946?v=2&amp;s=400" property="og:image" /><meta content="stefanbuck/github-linker-core" property="og:title" /><meta content="https://github.com/stefanbuck/github-linker-core" property="og:url" /><meta content="github-linker-core - The GitHub Linker core" property="og:description" />
+      <meta content="@github" name="twitter:site" /><meta content="summary" name="twitter:card" /><meta content="spacewander/test" name="twitter:title" /><meta content="a repo used for test" name="twitter:description" /><meta content="https://avatars1.githubusercontent.com/u/4161644?v=2&amp;s=400" name="twitter:image:src" />
+<meta content="GitHub" property="og:site_name" /><meta content="object" property="og:type" /><meta content="https://avatars1.githubusercontent.com/u/4161644?v=2&amp;s=400" property="og:image" /><meta content="spacewander/test" property="og:title" /><meta content="https://github.com/spacewander/test" property="og:url" /><meta content="a repo used for test" property="og:description" />
 
       <meta name="browser-stats-url" content="/_stats">
     <link rel="assets" href="https://assets-cdn.github.com/">
     <link rel="conduit-xhr" href="https://ghconduit.com:25035">
-
+    <link rel="xhr-socket" href="/_sockets">
+    <meta name="pjax-timeout" content="1000">
 
     <meta name="msapplication-TileImage" content="/windows-tile.png">
     <meta name="msapplication-TileColor" content="#ffffff">
     <meta name="selected-link" value="repo_source" data-pjax-transient>
       <meta name="google-analytics" content="UA-3769691-2">
 
-    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="54B6FADE:13B0:26CD25C:54135E8A" name="octolytics-dimension-request_id" />
+    <meta content="collector.githubapp.com" name="octolytics-host" /><meta content="collector-cdn.github.com" name="octolytics-script-host" /><meta content="github" name="octolytics-app-id" /><meta content="B73E39E1:4288:4486A77:54395CFE" name="octolytics-dimension-request_id" /><meta content="4161644" name="octolytics-actor-id" /><meta content="spacewander" name="octolytics-actor-login" /><meta content="6d1084e9fa8cb9775d899ebb28a78e284854d62e32f39a4cd4e73563fbc25be5" name="octolytics-actor-hash" />
     <meta content="Rails, view, blob#show" name="analytics-event" />
 
-
-
+    
+    
     <link rel="icon" type="image/x-icon" href="https://assets-cdn.github.com/favicon.ico">
 
 
     <meta content="authenticity_token" name="csrf-param" />
-<meta content="DeI7rPbzlnH9YUUm/3hUj4MfoLBmN2EgUnF1miq62UwGn9ohFfYaoOiDj0pzuBKQVFyTpGe/UcB7n8tHxeG0IA==" name="csrf-token" />
+<meta content="NZLj/ZhfJ0cSH1wO4bwJE69qZiM9+SqVCeF1Z5pnNSjPq6H05OTdX9EzKPbLXBmvn/Mzn41llEKASMlzHU+44Q==" name="csrf-token" />
 
-    <link href="https://assets-cdn.github.com/assets/github-49c9bbf9f4590464685eb8116415c480ddf8af23.css" media="all" rel="stylesheet" type="text/css" />
-    <link href="https://assets-cdn.github.com/assets/github2-567b17c7ed8d557f1d161e3b96b366310b9638b0.css" media="all" rel="stylesheet" type="text/css" />
-
-
-
-    <meta http-equiv="x-pjax-version" content="f559fa320d3ac556592cf9ab60ec6060">
+    <link href="https://assets-cdn.github.com/assets/github-043670bf5d45762c99c890603216d8776470fa11262837b5ba8ca37f4175d357.css" media="all" rel="stylesheet" type="text/css" />
+    <link href="https://assets-cdn.github.com/assets/github2-f97cae5c72db1b1729daa66251ec6bbfed848d4af992c2f4842aed69d5cc5277.css" media="all" rel="stylesheet" type="text/css" />
+    
+    
 
 
-  <meta name="description" content="github-linker-core - The GitHub Linker core">
-  <meta name="go-import" content="github.com/stefanbuck/github-linker-core git https://github.com/stefanbuck/github-linker-core.git">
+    <meta http-equiv="x-pjax-version" content="1bc26f375a269a3b5dc66c8831eeb112">
 
-  <meta content="1393946" name="octolytics-dimension-user_id" /><meta content="stefanbuck" name="octolytics-dimension-user_login" /><meta content="23393660" name="octolytics-dimension-repository_id" /><meta content="stefanbuck/github-linker-core" name="octolytics-dimension-repository_nwo" /><meta content="true" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="23393660" name="octolytics-dimension-repository_network_root_id" /><meta content="stefanbuck/github-linker-core" name="octolytics-dimension-repository_network_root_nwo" />
-  <link href="https://github.com/stefanbuck/github-linker-core/commits/master.atom" rel="alternate" title="Recent Commits to github-linker-core:master" type="application/atom+xml">
+      
+  <meta name="description" content="a repo used for test">
+  <meta name="go-import" content="github.com/spacewander/test git https://github.com/spacewander/test.git">
+
+  <meta content="4161644" name="octolytics-dimension-user_id" /><meta content="spacewander" name="octolytics-dimension-user_login" /><meta content="25085884" name="octolytics-dimension-repository_id" /><meta content="spacewander/test" name="octolytics-dimension-repository_nwo" /><meta content="false" name="octolytics-dimension-repository_public" /><meta content="false" name="octolytics-dimension-repository_is_fork" /><meta content="25085884" name="octolytics-dimension-repository_network_root_id" /><meta content="spacewander/test" name="octolytics-dimension-repository_network_root_nwo" />
+  <link href="https://github.com/spacewander/test/commits/c01ae7e78a4747302782cb58238797ef257fa617.atom?token=4161644__eyJzY29wZSI6IkF0b206L3NwYWNld2FuZGVyL3Rlc3QvY29tbWl0cy9jMDFhZTdlNzhhNDc0NzMwMjc4MmNiNTgyMzg3OTdlZjI1N2ZhNjE3LmF0b20iLCJleHBpcmVzIjoyOTkwOTY4NzAyfQ%3D%3D--a0f8573870b2c21f44e0bf4745526a9a6ef459f8" rel="alternate" title="Recent Commits to test:c01ae7e78a4747302782cb58238797ef257fa617" type="application/atom+xml">
 
   </head>
 
 
-  <body class="logged_out  env-production macintosh vis-public page-blob">
+  <body class="logged_in  env-production linux vis-private page-blob">
     <a href="#start-of-content" tabindex="1" class="accessibility-aid js-skip-to-content">Skip to content</a>
     <div class="wrapper">
+      
+      
+      
+      
 
 
-
-
-
-
-
-      <div class="header header-logged-out">
+      <div class="header header-logged-in true" role="banner">
   <div class="container clearfix">
 
-    <a class="header-logo-wordmark" href="https://github.com/" ga-data-click="(Logged out) Header, go to homepage, icon:logo-wordmark">
-      <span class="mega-octicon octicon-logo-github"></span>
-    </a>
+    <a class="header-logo-invertocat" href="https://github.com/" data-hotkey="g d" aria-label="Homepage" ga-data-click="Header, go to dashboard, icon:logo">
+  <span class="mega-octicon octicon-mark-github"></span>
+</a>
 
-    <div class="header-actions">
-        <a class="button primary" href="/join" data-ga-click="(Logged out) Header, clicked Sign up, text:sign-up">Sign up</a>
-      <a class="button signin" href="/login?return_to=%2Fstefanbuck%2Fgithub-linker-core%2Fblob%2Fmaster%2Ftest%2Ffixtures%2Fpackage.json" data-ga-click="(Logged out) Header, clicked Sign in, text:sign-in">Sign in</a>
-    </div>
 
-    <div class="site-search repo-scope js-site-search">
-      <form accept-charset="UTF-8" action="/stefanbuck/github-linker-core/search" class="js-site-search-form" data-global-search-url="/search" data-repo-search-url="/stefanbuck/github-linker-core/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
+      <div class="site-search repo-scope js-site-search" role="search">
+          <form accept-charset="UTF-8" action="/spacewander/test/search" class="js-site-search-form" data-global-search-url="/search" data-repo-search-url="/spacewander/test/search" method="get"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /></div>
   <input type="text"
     class="js-site-search-field is-clearable"
     data-hotkey="s"
@@ -91,71 +92,225 @@
     autocapitalize="off">
   <div class="scope-badge">This repository</div>
 </form>
-    </div>
-
-      <ul class="header-nav left">
+      </div>
+      <ul class="header-nav left" role="navigation">
+        <li class="header-nav-item explore">
+          <a class="header-nav-link" href="/explore" data-ga-click="Header, go to explore, text:explore">Explore</a>
+        </li>
           <li class="header-nav-item">
-            <a class="header-nav-link" href="/explore" data-ga-click="(Logged out) Header, go to explore, text:explore">Explore</a>
+            <a class="header-nav-link" href="https://gist.github.com" data-ga-click="Header, go to gist, text:gist">Gist</a>
           </li>
           <li class="header-nav-item">
-            <a class="header-nav-link" href="/features" data-ga-click="(Logged out) Header, go to features, text:features">Features</a>
+            <a class="header-nav-link" href="/blog" data-ga-click="Header, go to blog, text:blog">Blog</a>
           </li>
-          <li class="header-nav-item">
-            <a class="header-nav-link" href="https://enterprise.github.com/" data-ga-click="(Logged out) Header, go to enterprise, text:enterprise">Enterprise</a>
-          </li>
-          <li class="header-nav-item">
-            <a class="header-nav-link" href="/blog" data-ga-click="(Logged out) Header, go to blog, text:blog">Blog</a>
-          </li>
+        <li class="header-nav-item">
+          <a class="header-nav-link" href="https://help.github.com" data-ga-click="Header, go to help, text:help">Help</a>
+        </li>
       </ul>
 
+    
+<ul class="header-nav user-nav right" id="user-links">
+  <li class="header-nav-item dropdown js-menu-container">
+    <a class="header-nav-link name" href="/spacewander" data-ga-click="Header, go to profile, text:username">
+      <img alt="spacewander" class="avatar" data-user="4161644" height="20" src="https://avatars2.githubusercontent.com/u/4161644?v=2&amp;s=40" width="20" />
+      <span class="css-truncate">
+        <span class="css-truncate-target">spacewander</span>
+      </span>
+    </a>
+  </li>
+
+  <li class="header-nav-item dropdown js-menu-container">
+    <a class="header-nav-link js-menu-target tooltipped tooltipped-s" href="#" aria-label="Create new..." data-ga-click="Header, create new, icon:add">
+      <span class="octicon octicon-plus"></span>
+      <span class="dropdown-caret"></span>
+    </a>
+
+    <div class="dropdown-menu-content js-menu-content">
+      
+<ul class="dropdown-menu">
+  <li>
+    <a href="/new"><span class="octicon octicon-repo"></span> New repository</a>
+  </li>
+  <li>
+    <a href="/organizations/new"><span class="octicon octicon-organization"></span> New organization</a>
+  </li>
+
+
+    <li class="dropdown-divider"></li>
+    <li class="dropdown-header">
+      <span title="spacewander/test">This repository</span>
+    </li>
+      <li>
+        <a href="/spacewander/test/issues/new"><span class="octicon octicon-issue-opened"></span> New issue</a>
+      </li>
+      <li>
+        <a href="/spacewander/test/settings/collaboration"><span class="octicon octicon-person"></span> New collaborator</a>
+      </li>
+</ul>
+
+    </div>
+  </li>
+
+  <li class="header-nav-item">
+        <a href="/notifications" aria-label="You have no unread notifications" class="header-nav-link notification-indicator tooltipped tooltipped-s" data-ga-click="Header, go to notifications, icon:read" data-hotkey="g n">
+        <span class="mail-status all-read"></span>
+        <span class="octicon octicon-inbox"></span>
+</a>
+  </li>
+
+  <li class="header-nav-item">
+    <a class="header-nav-link tooltipped tooltipped-s" href="/settings/profile" id="account_settings" aria-label="Settings" data-ga-click="Header, go to settings, icon:settings">
+      <span class="octicon octicon-gear"></span>
+    </a>
+  </li>
+
+  <li class="header-nav-item">
+    <form accept-charset="UTF-8" action="/logout" class="logout-form" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="u3Kt1kJ0aMKBN4J1XMuAoQwaBkdHEubuG5CEpPgIUEl/UYpIYduu3R6gXvP/DqPZoSQPLjopDmXl2D2j+DgikQ==" /></div>
+      <button class="header-nav-link sign-out-button tooltipped tooltipped-s" aria-label="Sign out" data-ga-click="Header, sign out, icon:logout">
+        <span class="octicon octicon-sign-out"></span>
+      </button>
+</form>  </li>
+
+</ul>
+
+
+    
   </div>
 </div>
 
+      
+
+        
 
 
       <div id="start-of-content" class="accessibility-aid"></div>
           <div class="site" itemscope itemtype="http://schema.org/WebPage">
     <div id="js-flash-container">
-
+      
     </div>
     <div class="pagehead repohead instapaper_ignore readability-menu">
       <div class="container">
-
+        
 <ul class="pagehead-actions">
 
+    <li class="subscription">
+      <form accept-charset="UTF-8" action="/notifications/subscribe" class="js-social-container" data-autosubmit="true" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="dOCFteJB7iSzKZYlvREa30UYaYkbAJ4noijCgVAUY1Muiwy3gVZj1kQKmXdTE0rIEBdpraORkyia3a4vmIw/zQ==" /></div>  <input id="repository_id" name="repository_id" type="hidden" value="25085884" />
+
+    <div class="select-menu js-menu-container js-select-menu">
+      <a class="social-count js-social-count" href="/spacewander/test/watchers">
+        1
+      </a>
+      <a href="/spacewander/test/subscription"
+        class="minibutton select-menu-button with-count js-menu-target" role="button" tabindex="0" aria-haspopup="true">
+        <span class="js-select-button">
+          <span class="octicon octicon-eye"></span>
+          Unwatch
+        </span>
+      </a>
+
+      <div class="select-menu-modal-holder">
+        <div class="select-menu-modal subscription-menu-modal js-menu-content" aria-hidden="true">
+          <div class="select-menu-header">
+            <span class="select-menu-title">Notifications</span>
+            <span class="octicon octicon-x js-menu-close" role="button" aria-label="Close"></span>
+          </div> <!-- /.select-menu-header -->
+
+          <div class="select-menu-list js-navigation-container" role="menu">
+
+            <div class="select-menu-item js-navigation-item " role="menuitem" tabindex="0">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <div class="select-menu-item-text">
+                <input id="do_included" name="do" type="radio" value="included" />
+                <h4>Not watching</h4>
+                <span class="description">Be notified when participating or @mentioned.</span>
+                <span class="js-select-button-text hidden-select-button-text">
+                  <span class="octicon octicon-eye"></span>
+                  Watch
+                </span>
+              </div>
+            </div> <!-- /.select-menu-item -->
+
+            <div class="select-menu-item js-navigation-item selected" role="menuitem" tabindex="0">
+              <span class="select-menu-item-icon octicon octicon octicon-check"></span>
+              <div class="select-menu-item-text">
+                <input checked="checked" id="do_subscribed" name="do" type="radio" value="subscribed" />
+                <h4>Watching</h4>
+                <span class="description">Be notified of all conversations.</span>
+                <span class="js-select-button-text hidden-select-button-text">
+                  <span class="octicon octicon-eye"></span>
+                  Unwatch
+                </span>
+              </div>
+            </div> <!-- /.select-menu-item -->
+
+            <div class="select-menu-item js-navigation-item " role="menuitem" tabindex="0">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <div class="select-menu-item-text">
+                <input id="do_ignore" name="do" type="radio" value="ignore" />
+                <h4>Ignoring</h4>
+                <span class="description">Never be notified.</span>
+                <span class="js-select-button-text hidden-select-button-text">
+                  <span class="octicon octicon-mute"></span>
+                  Stop ignoring
+                </span>
+              </div>
+            </div> <!-- /.select-menu-item -->
+
+          </div> <!-- /.select-menu-list -->
+
+        </div> <!-- /.select-menu-modal -->
+      </div> <!-- /.select-menu-modal-holder -->
+    </div> <!-- /.select-menu -->
+
+</form>
+    </li>
 
   <li>
-      <a href="/login?return_to=%2Fstefanbuck%2Fgithub-linker-core"
-    class="minibutton with-count star-button tooltipped tooltipped-n"
-    aria-label="You must be signed in to star a repository" rel="nofollow">
-    <span class="octicon octicon-star"></span>
-    Star
-  </a>
+    
+  <div class="js-toggler-container js-social-container starring-container ">
 
-    <a class="social-count js-social-count" href="/stefanbuck/github-linker-core/stargazers">
-      0
-    </a>
+    <form accept-charset="UTF-8" action="/spacewander/test/unstar" class="js-toggler-form starred js-unstar-button" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="wyFqP7pb78szCIogpAoDEaSuEzrU9yd5UuEWVO/mLDBURSH3t6EHvRawfCA9wzXQoctMkMkJTrKPTRXj8EWIDg==" /></div>
+      <button
+        class="minibutton with-count js-toggler-target star-button"
+        aria-label="Unstar this repository" title="Unstar spacewander/test">
+        <span class="octicon octicon-star"></span>
+        Unstar
+      </button>
+        <a class="social-count js-social-count" href="/spacewander/test/stargazers">
+          0
+        </a>
+</form>
+    <form accept-charset="UTF-8" action="/spacewander/test/star" class="js-toggler-form unstarred js-star-button" data-remote="true" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="2g+x93fP+6uQfl9Oa+o8jjIyrcuI09KtllefZbJFKpr/4d5kxpkaAn4pQmAKKvAfQz+xf+mx73ooKJKEInfrEg==" /></div>
+      <button
+        class="minibutton with-count js-toggler-target star-button"
+        aria-label="Star this repository" title="Star spacewander/test">
+        <span class="octicon octicon-star"></span>
+        Star
+      </button>
+        <a class="social-count js-social-count" href="/spacewander/test/stargazers">
+          0
+        </a>
+</form>  </div>
 
   </li>
 
-    <li>
-      <a href="/login?return_to=%2Fstefanbuck%2Fgithub-linker-core"
-        class="minibutton with-count js-toggler-target fork-button tooltipped tooltipped-n"
-        aria-label="You must be signed in to fork a repository" rel="nofollow">
-        <span class="octicon octicon-repo-forked"></span>
-        Fork
-      </a>
-      <a href="/stefanbuck/github-linker-core/network" class="social-count">
-        0
-      </a>
-    </li>
+
+        <li>
+          <a href="/spacewander/test/fork" class="minibutton with-count js-toggler-target fork-button tooltipped-n" title="Fork your own copy of spacewander/test to your account" aria-label="Fork your own copy of spacewander/test to your account" rel="facebox nofollow">
+            <span class="octicon octicon-repo-forked"></span>
+            Fork
+          </a>
+          <a href="/spacewander/test/network" class="social-count">0</a>
+        </li>
+
 </ul>
 
-        <h1 itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="entry-title public">
-          <span class="mega-octicon octicon-repo"></span>
-          <span class="author"><a href="/stefanbuck" class="url fn" itemprop="url" rel="author"><span itemprop="title">stefanbuck</span></a></span><!--
+        <h1 itemscope itemtype="http://data-vocabulary.org/Breadcrumb" class="entry-title private">
+          <span class="mega-octicon octicon-lock"></span>
+          <span class="author"><a href="/spacewander" class="url fn" itemprop="url" rel="author"><span itemprop="title">spacewander</span></a></span><!--
        --><span class="path-divider">/</span><!--
-       --><strong><a href="/stefanbuck/github-linker-core" class="js-current-repository js-repo-home-link">github-linker-core</a></strong>
+       --><strong><a href="/spacewander/test" class="js-current-repository js-repo-home-link">test</a></strong>
+            <span class="repo-private-label">private</span>
 
           <span class="page-context-loader">
             <img alt="" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
@@ -168,101 +323,125 @@
     <div class="container">
       <div class="repository-with-sidebar repo-container new-discussion-timeline  ">
         <div class="repository-sidebar clearfix">
-
-<div class="sunken-menu vertical-right repo-nav js-repo-nav js-repository-container-pjax js-octicon-loaders" data-issue-count-url="/stefanbuck/github-linker-core/issues/counts">
+            
+<div class="sunken-menu vertical-right repo-nav js-repo-nav js-repository-container-pjax js-octicon-loaders" role="navigation" data-issue-count-url="/spacewander/test/issues/counts">
   <div class="sunken-menu-contents">
     <ul class="sunken-menu-group">
       <li class="tooltipped tooltipped-w" aria-label="Code">
-        <a href="/stefanbuck/github-linker-core" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-hotkey="g c" data-pjax="true" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /stefanbuck/github-linker-core">
+        <a href="/spacewander/test" aria-label="Code" class="selected js-selected-navigation-item sunken-menu-item" data-hotkey="g c" data-pjax="true" data-selected-links="repo_source repo_downloads repo_commits repo_releases repo_tags repo_branches /spacewander/test">
           <span class="octicon octicon-code"></span> <span class="full-word">Code</span>
           <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>      </li>
 
         <li class="tooltipped tooltipped-w" aria-label="Issues">
-          <a href="/stefanbuck/github-linker-core/issues" aria-label="Issues" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /stefanbuck/github-linker-core/issues">
+          <a href="/spacewander/test/issues" aria-label="Issues" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-hotkey="g i" data-selected-links="repo_issues repo_labels repo_milestones /spacewander/test/issues">
             <span class="octicon octicon-issue-opened"></span> <span class="full-word">Issues</span>
             <span class="js-issue-replace-counter"></span>
             <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>        </li>
 
       <li class="tooltipped tooltipped-w" aria-label="Pull Requests">
-        <a href="/stefanbuck/github-linker-core/pulls" aria-label="Pull Requests" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-hotkey="g p" data-selected-links="repo_pulls /stefanbuck/github-linker-core/pulls">
+        <a href="/spacewander/test/pulls" aria-label="Pull Requests" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-hotkey="g p" data-selected-links="repo_pulls /spacewander/test/pulls">
             <span class="octicon octicon-git-pull-request"></span> <span class="full-word">Pull Requests</span>
             <span class="js-pull-replace-counter"></span>
             <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>      </li>
 
 
+        <li class="tooltipped tooltipped-w" aria-label="Wiki">
+          <a href="/spacewander/test/wiki" aria-label="Wiki" class="js-selected-navigation-item sunken-menu-item js-disable-pjax" data-hotkey="g w" data-selected-links="repo_wiki /spacewander/test/wiki">
+            <span class="octicon octicon-book"></span> <span class="full-word">Wiki</span>
+            <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>        </li>
     </ul>
     <div class="sunken-menu-separator"></div>
     <ul class="sunken-menu-group">
 
       <li class="tooltipped tooltipped-w" aria-label="Pulse">
-        <a href="/stefanbuck/github-linker-core/pulse/weekly" aria-label="Pulse" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="pulse /stefanbuck/github-linker-core/pulse/weekly">
+        <a href="/spacewander/test/pulse/weekly" aria-label="Pulse" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="pulse /spacewander/test/pulse/weekly">
           <span class="octicon octicon-pulse"></span> <span class="full-word">Pulse</span>
           <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>      </li>
 
       <li class="tooltipped tooltipped-w" aria-label="Graphs">
-        <a href="/stefanbuck/github-linker-core/graphs" aria-label="Graphs" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="repo_graphs repo_contributors /stefanbuck/github-linker-core/graphs">
+        <a href="/spacewander/test/graphs" aria-label="Graphs" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="repo_graphs repo_contributors /spacewander/test/graphs">
           <span class="octicon octicon-graph"></span> <span class="full-word">Graphs</span>
           <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
 </a>      </li>
     </ul>
 
 
+      <div class="sunken-menu-separator"></div>
+      <ul class="sunken-menu-group">
+        <li class="tooltipped tooltipped-w" aria-label="Settings">
+          <a href="/spacewander/test/settings" aria-label="Settings" class="js-selected-navigation-item sunken-menu-item" data-pjax="true" data-selected-links="repo_settings /spacewander/test/settings">
+            <span class="octicon octicon-tools"></span> <span class="full-word">Settings</span>
+            <img alt="" class="mini-loader" height="16" src="https://assets-cdn.github.com/images/spinners/octocat-spinner-32.gif" width="16" />
+</a>        </li>
+      </ul>
   </div>
 </div>
 
               <div class="only-with-full-nav">
-
-
+                
+  
 <div class="clone-url open"
   data-protocol-type="http"
-  data-url="/users/set_protocol?protocol_selector=http&amp;protocol_type=clone">
+  data-url="/users/set_protocol?protocol_selector=http&amp;protocol_type=push">
   <h3><span class="text-emphasized">HTTPS</span> clone URL</h3>
   <div class="input-group">
     <input type="text" class="input-mini input-monospace js-url-field"
-           value="https://github.com/stefanbuck/github-linker-core.git" readonly="readonly">
+           value="https://github.com/spacewander/test.git" readonly="readonly">
     <span class="input-group-button">
-      <button aria-label="Copy to clipboard" class="js-zeroclipboard minibutton zeroclipboard-button" data-clipboard-text="https://github.com/stefanbuck/github-linker-core.git" data-copied-hint="Copied!" type="button"><span class="octicon octicon-clippy"></span></button>
+      <button aria-label="Copy to clipboard" class="js-zeroclipboard minibutton zeroclipboard-button" data-clipboard-text="https://github.com/spacewander/test.git" data-copied-hint="Copied!" type="button"><span class="octicon octicon-clippy"></span></button>
     </span>
   </div>
 </div>
 
+  
+<div class="clone-url "
+  data-protocol-type="ssh"
+  data-url="/users/set_protocol?protocol_selector=ssh&amp;protocol_type=push">
+  <h3><span class="text-emphasized">SSH</span> clone URL</h3>
+  <div class="input-group">
+    <input type="text" class="input-mini input-monospace js-url-field"
+           value="git@github.com:spacewander/test.git" readonly="readonly">
+    <span class="input-group-button">
+      <button aria-label="Copy to clipboard" class="js-zeroclipboard minibutton zeroclipboard-button" data-clipboard-text="git@github.com:spacewander/test.git" data-copied-hint="Copied!" type="button"><span class="octicon octicon-clippy"></span></button>
+    </span>
+  </div>
+</div>
 
+  
 <div class="clone-url "
   data-protocol-type="subversion"
-  data-url="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=clone">
+  data-url="/users/set_protocol?protocol_selector=subversion&amp;protocol_type=push">
   <h3><span class="text-emphasized">Subversion</span> checkout URL</h3>
   <div class="input-group">
     <input type="text" class="input-mini input-monospace js-url-field"
-           value="https://github.com/stefanbuck/github-linker-core" readonly="readonly">
+           value="https://github.com/spacewander/test" readonly="readonly">
     <span class="input-group-button">
-      <button aria-label="Copy to clipboard" class="js-zeroclipboard minibutton zeroclipboard-button" data-clipboard-text="https://github.com/stefanbuck/github-linker-core" data-copied-hint="Copied!" type="button"><span class="octicon octicon-clippy"></span></button>
+      <button aria-label="Copy to clipboard" class="js-zeroclipboard minibutton zeroclipboard-button" data-clipboard-text="https://github.com/spacewander/test" data-copied-hint="Copied!" type="button"><span class="octicon octicon-clippy"></span></button>
     </span>
   </div>
 </div>
 
 
 <p class="clone-options">You can clone with
-      <a href="#" class="js-clone-selector" data-protocol="http">HTTPS</a>
+      <a href="#" class="js-clone-selector" data-protocol="http">HTTPS</a>,
+      <a href="#" class="js-clone-selector" data-protocol="ssh">SSH</a>,
       or <a href="#" class="js-clone-selector" data-protocol="subversion">Subversion</a>.
   <a href="https://help.github.com/articles/which-remote-url-should-i-use" class="help tooltipped tooltipped-n" aria-label="Get help on which URL is right for you.">
     <span class="octicon octicon-question"></span>
   </a>
 </p>
 
-  a href="http://mac.github.com" data-url="github-mac://openRepo/https://github.com/stefanbuck/github-linker-core" class="minibutton sidebar-button js-conduit-rewrite-url" title="Save stefanbuck/github-linker-core to your computer and use it in GitHub Desktop." aria-label="Save stefanbuck/github-linker-core to your computer and use it in GitHub Desktop.">
-    <span class="octicon octicon-device-desktop"></span>
-    Clone in Desktop
-  </a>
 
 
-                <a href="/stefanbuck/github-linker-core/archive/master.zip"
+                <a href="/spacewander/test/archive/c01ae7e78a4747302782cb58238797ef257fa617.zip"
                    class="minibutton sidebar-button"
-                   aria-label="Download the contents of stefanbuck/github-linker-core as a zip file"
-                   title="Download the contents of stefanbuck/github-linker-core as a zip file"
+                   aria-label="Download the contents of spacewander/test as a zip file"
+                   title="Download the contents of spacewander/test as a zip file"
                    rel="nofollow">
                   <span class="octicon octicon-cloud-download"></span>
                   Download ZIP
@@ -271,23 +450,23 @@
         </div><!-- /.repository-sidebar -->
 
         <div id="js-repo-pjax-container" class="repository-content context-loader-container" data-pjax-container>
+          
 
+<a href="/spacewander/test/blob/c01ae7e78a4747302782cb58238797ef257fa617/test/fixtures/package.json" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
 
-<a href="/stefanbuck/github-linker-core/blob/55de431e1efe52379f871907efecfe0e9157d6ad/test/fixtures/package.json" class="hidden js-permalink-shortcut" data-hotkey="y">Permalink</a>
-
-<!-- blob contrib key: blob_contributors:v21:a87911875bd9a61a4b3db91408d3664a -->
+<!-- blob contrib key: blob_contributors:v21:47fa3aaefb86b8ff81849ebc0d261106 -->
 
 <div class="file-navigation">
-
+  
 <div class="select-menu js-menu-container js-select-menu left">
   <span class="minibutton select-menu-button js-menu-target css-truncate" data-hotkey="w"
     data-master-branch="master"
-    data-ref="master"
-    title="master"
+    data-ref=""
+    title=""
     role="button" aria-label="Switch branches or tags" tabindex="0" aria-haspopup="true">
     <span class="octicon octicon-git-branch"></span>
-    <i>branch:</i>
-    <span class="js-select-button css-truncate-target">master</span>
+    <i>tree:</i>
+    <span class="js-select-button css-truncate-target">c01ae7e78a</span>
   </span>
 
   <div class="select-menu-modal-holder js-menu-content js-navigation-container" data-pjax aria-hidden="true">
@@ -300,7 +479,7 @@
 
       <div class="select-menu-filters">
         <div class="select-menu-text-filter">
-          <input type="text" aria-label="Filter branches/tags" id="context-commitish-filter-field" class="js-filterable-field js-navigation-enable" placeholder="Filter branches/tags">
+          <input type="text" aria-label="Find or create a branch…" id="context-commitish-filter-field" class="js-filterable-field js-navigation-enable" placeholder="Find or create a branch…">
         </div>
         <div class="select-menu-tabs">
           <ul>
@@ -319,9 +498,18 @@
         <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
 
 
-            <div class="select-menu-item js-navigation-item selected">
+            <div class="select-menu-item js-navigation-item ">
               <span class="select-menu-item-icon octicon octicon-check"></span>
-              <a href="/stefanbuck/github-linker-core/blob/master/test/fixtures/package.json"
+              <a href="/spacewander/test/blob/develop/test/fixtures/package.json"
+                 data-name="develop"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text css-truncate-target"
+                 title="develop">develop</a>
+            </div> <!-- /.select-menu-item -->
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/spacewander/test/blob/master/test/fixtures/package.json"
                  data-name="master"
                  data-skip-pjax="true"
                  rel="nofollow"
@@ -330,13 +518,32 @@
             </div> <!-- /.select-menu-item -->
         </div>
 
-          <div class="select-menu-no-results">Nothing to show</div>
+          <form accept-charset="UTF-8" action="/spacewander/test/branches" class="js-create-branch select-menu-item select-menu-new-item-form js-navigation-item js-new-item-form" method="post"><div style="margin:0;padding:0;display:inline"><input name="utf8" type="hidden" value="&#x2713;" /><input name="authenticity_token" type="hidden" value="Ldmiznbw4UvGw+hJlJPfhXvy+3Wn+Y0Lx4HO7rHa8WsvqH0SKZmOrYlcVq+1TARkagGvCRFEUkXpx0Tld1WbZw==" /></div>
+            <span class="octicon octicon-git-branch select-menu-item-icon"></span>
+            <div class="select-menu-item-text">
+              <h4>Create branch: <span class="js-new-item-name"></span></h4>
+              <span class="description">from ‘c01ae7e’</span>
+            </div>
+            <input type="hidden" name="name" id="name" class="js-new-item-value">
+            <input type="hidden" name="branch" id="branch" value="c01ae7e78a4747302782cb58238797ef257fa617">
+            <input type="hidden" name="path" id="path" value="test/fixtures/package.json">
+          </form> <!-- /.select-menu-item -->
+
       </div> <!-- /.select-menu-list -->
 
       <div class="select-menu-list select-menu-tab-bucket js-select-menu-tab-bucket" data-tab-filter="tags">
         <div data-filterable-for="context-commitish-filter-field" data-filterable-type="substring">
 
 
+            <div class="select-menu-item js-navigation-item ">
+              <span class="select-menu-item-icon octicon octicon-check"></span>
+              <a href="/spacewander/test/tree/v1.0.2/test/fixtures/package.json"
+                 data-name="v1.0.2"
+                 data-skip-pjax="true"
+                 rel="nofollow"
+                 class="js-navigation-open select-menu-item-text css-truncate-target"
+                 title="v1.0.2">v1.0.2</a>
+            </div> <!-- /.select-menu-item -->
         </div>
 
         <div class="select-menu-no-results">Nothing to show</div>
@@ -347,7 +554,7 @@
 </div> <!-- /.select-menu -->
 
   <div class="button-group right">
-    <a href="/stefanbuck/github-linker-core/find/master"
+    <a href="/spacewander/test/find/c01ae7e78a4747302782cb58238797ef257fa617"
           class="js-show-file-finder minibutton empty-icon tooltipped tooltipped-s"
           data-pjax
           data-hotkey="t"
@@ -363,28 +570,31 @@
   </div>
 
   <div class="breadcrumb">
-    <span class='repo-root js-repo-root'><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/stefanbuck/github-linker-core" class="" data-branch="master" data-direction="back" data-pjax="true" itemscope="url"><span itemprop="title">github-linker-core</span></a></span></span><span class="separator"> / </span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/stefanbuck/github-linker-core/tree/master/test" class="" data-branch="master" data-direction="back" data-pjax="true" itemscope="url"><span itemprop="title">test</span></a></span><span class="separator"> / </span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/stefanbuck/github-linker-core/tree/master/test/fixtures" class="" data-branch="master" data-direction="back" data-pjax="true" itemscope="url"><span itemprop="title">fixtures</span></a></span><span class="separator"> / </span><strong class="final-path">package.json</strong>
+    <span class='repo-root js-repo-root'><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/spacewander/test/tree/c01ae7e78a4747302782cb58238797ef257fa617" class="" data-branch="c01ae7e78a4747302782cb58238797ef257fa617" data-direction="back" data-pjax="true" itemscope="url" rel="nofollow"><span itemprop="title">test</span></a></span></span><span class="separator"> / </span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/spacewander/test/tree/c01ae7e78a4747302782cb58238797ef257fa617/test" class="" data-branch="c01ae7e78a4747302782cb58238797ef257fa617" data-direction="back" data-pjax="true" itemscope="url" rel="nofollow"><span itemprop="title">test</span></a></span><span class="separator"> / </span><span itemscope="" itemtype="http://data-vocabulary.org/Breadcrumb"><a href="/spacewander/test/tree/c01ae7e78a4747302782cb58238797ef257fa617/test/fixtures" class="" data-branch="c01ae7e78a4747302782cb58238797ef257fa617" data-direction="back" data-pjax="true" itemscope="url" rel="nofollow"><span itemprop="title">fixtures</span></a></span><span class="separator"> / </span><strong class="final-path">package.json</strong>
   </div>
 </div>
 
 
   <div class="commit file-history-tease">
     <div class="file-history-tease-header">
-        <img alt="Stefan Buck" class="avatar" data-user="1393946" height="24" src="https://avatars2.githubusercontent.com/u/1393946?v=2&amp;s=48" width="24" />
-        <span class="author"><a href="/stefanbuck" rel="author">stefanbuck</a></span>
-        <time datetime="2014-08-28T06:44:39+02:00" is="relative-time">August 28, 2014</time>
+        <img alt="spacewander" class="avatar" data-user="4161644" height="24" src="https://avatars0.githubusercontent.com/u/4161644?v=2&amp;s=48" width="24" />
+        <span class="author"><a href="/spacewander" rel="author">spacewander</a></span>
+        <time datetime="2014-10-11T16:26:08Z" is="relative-time">Oct 12, 2014</time>
         <div class="commit-title">
-            <a href="/stefanbuck/github-linker-core/commit/ef0d9ab06ed5edbf74f5cd31905d04aa79f45fbc" class="message" data-pjax="true" title="Create package.json">Create package.json</a>
+            <a href="/spacewander/test/commit/c01ae7e78a4747302782cb58238797ef257fa617" class="message" data-pjax="true" title="Update package.json">Update package.json</a>
         </div>
     </div>
 
     <div class="participation">
       <p class="quickstat">
         <a href="#blob_contributors_box" rel="facebox">
-          <strong>1</strong>
-           contributor
+          <strong>2</strong>
+           contributors
         </a>
       </p>
+          <a class="avatar-link tooltipped tooltipped-s" aria-label="stefanbuck" href="/spacewander/test/commits/master/test/fixtures/package.json?author=stefanbuck"><img alt="Stefan Buck" class="avatar" data-user="1393946" height="20" src="https://avatars0.githubusercontent.com/u/1393946?v=2&amp;s=40" width="20" /></a>
+    <a class="avatar-link tooltipped tooltipped-s" aria-label="spacewander" href="/spacewander/test/commits/master/test/fixtures/package.json?author=spacewander"><img alt="spacewander" class="avatar" data-user="4161644" height="20" src="https://avatars2.githubusercontent.com/u/4161644?v=2&amp;s=40" width="20" /></a>
+
 
     </div>
     <div id="blob_contributors_box" style="display:none">
@@ -394,6 +604,10 @@
             <img alt="Stefan Buck" data-user="1393946" height="24" src="https://avatars2.githubusercontent.com/u/1393946?v=2&amp;s=48" width="24" />
             <a href="/stefanbuck">stefanbuck</a>
           </li>
+          <li class="facebox-user-list-item">
+            <img alt="spacewander" data-user="4161644" height="24" src="https://avatars0.githubusercontent.com/u/4161644?v=2&amp;s=48" width="24" />
+            <a href="/spacewander">spacewander</a>
+          </li>
       </ul>
     </div>
   </div>
@@ -402,35 +616,28 @@
   <div class="file">
     <div class="meta clearfix">
       <div class="info file-name">
-          <span>42 lines (41 sloc)</span>
+          <span>47 lines (46 sloc)</span>
           <span class="meta-divider"></span>
-        <span>1.173 kb</span>
+        <span>1.271 kb</span>
       </div>
       <div class="actions">
         <div class="button-group">
-          <a href="/stefanbuck/github-linker-core/raw/master/test/fixtures/package.json" class="minibutton " id="raw-url">Raw</a>
-            <a href="/stefanbuck/github-linker-core/blame/master/test/fixtures/package.json" class="minibutton js-update-url-with-hash">Blame</a>
-          <a href="/stefanbuck/github-linker-core/commits/master/test/fixtures/package.json" class="minibutton " rel="nofollow">History</a>
+          <a href="/spacewander/test/raw/c01ae7e78a4747302782cb58238797ef257fa617/test/fixtures/package.json" class="minibutton " id="raw-url">Raw</a>
+            <a href="/spacewander/test/blame/c01ae7e78a4747302782cb58238797ef257fa617/test/fixtures/package.json" class="minibutton js-update-url-with-hash">Blame</a>
+          <a href="/spacewander/test/commits/c01ae7e78a4747302782cb58238797ef257fa617/test/fixtures/package.json" class="minibutton " rel="nofollow">History</a>
         </div><!-- /.button-group -->
 
-          <a class="octicon-button tooltipped tooltipped-nw js-conduit-openfile-check"
-             href="http://mac.github.com"
-             data-url="github-mac://openRepo/https://github.com/stefanbuck/github-linker-core?branch=master&amp;filepath=test%2Ffixtures%2Fpackage.json"
-             aria-label="Open this file in GitHub for Mac"
-             data-failed-title="Your version of GitHub for Mac is too old to open this file. Try checking for updates.">
-              <span class="octicon octicon-device-desktop"></span>
-          </a>
 
             <a class="octicon-button disabled tooltipped tooltipped-w" href="#"
-               aria-label="You must be signed in to make or propose changes"><span class="octicon octicon-pencil"></span></a>
+               aria-label="You must be on a branch to make or propose changes to this file"><span class="octicon octicon-pencil"></span></a>
 
           <a class="octicon-button danger disabled tooltipped tooltipped-w" href="#"
-             aria-label="You must be signed in to make or propose changes">
+             aria-label="You must be on a branch to make or propose changes to this file">
           <span class="octicon octicon-trashcan"></span>
         </a>
       </div><!-- /.actions -->
     </div>
-
+    
   <div class="blob-wrapper data type-json">
       <table class="highlight tab-size-8 js-file-line-container">
       <tr>
@@ -463,139 +670,159 @@
       </tr>
       <tr>
         <td id="L8" class="blob-num js-line-number" data-line-number="8"></td>
-        <td id="LC8" class="blob-code js-file-line">    <span class="nt">&quot;main&quot;</span><span class="p">:</span> <span class="s2">&quot;index.js&quot;</span><span class="p">,</span></td>
+        <td id="LC8" class="blob-code js-file-line">    <span class="nt">&quot;directories&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L9" class="blob-num js-line-number" data-line-number="9"></td>
-        <td id="LC9" class="blob-code js-file-line">    <span class="nt">&quot;author&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC9" class="blob-code js-file-line">      <span class="nt">&quot;main&quot;</span><span class="p">:</span> <span class="s2">&quot;./main&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L10" class="blob-num js-line-number" data-line-number="10"></td>
-        <td id="LC10" class="blob-code js-file-line">        <span class="nt">&quot;name&quot;</span><span class="p">:</span> <span class="s2">&quot;Stefan Buck&quot;</span><span class="p">,</span></td>
+        <td id="LC10" class="blob-code js-file-line">      <span class="nt">&quot;bin&quot;</span><span class="p">:</span> <span class="s2">&quot;./bin&quot;</span></td>
       </tr>
       <tr>
         <td id="L11" class="blob-num js-line-number" data-line-number="11"></td>
-        <td id="LC11" class="blob-code js-file-line">        <span class="nt">&quot;email&quot;</span><span class="p">:</span> <span class="s2">&quot;dev@stefanbuck.com&quot;</span><span class="p">,</span></td>
+        <td id="LC11" class="blob-code js-file-line">    <span class="p">},</span></td>
       </tr>
       <tr>
         <td id="L12" class="blob-num js-line-number" data-line-number="12"></td>
-        <td id="LC12" class="blob-code js-file-line">        <span class="nt">&quot;url&quot;</span><span class="p">:</span> <span class="s2">&quot;http://stefanbuck.com&quot;</span>/td>
+        <td id="LC12" class="blob-code js-file-line">    <span class="nt">&quot;bin&quot;</span><span class="p">:</span> <span class="s2">&quot;./index.js&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L13" class="blob-num js-line-number" data-line-number="13"></td>
-        <td id="LC13" class="blob-code js-file-line">    <span class="p">},</span></td>
+        <td id="LC13" class="blob-code js-file-line">    <span class="nt">&quot;main&quot;</span><span class="p">:</span> <span class="s2">&quot;index.js&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L14" class="blob-num js-line-number" data-line-number="14"></td>
-        <td id="LC14" class="blob-code js-file-line">    <span class="nt">&quot;repository&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC14" class="blob-code js-file-line">    <span class="nt">&quot;author&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L15" class="blob-num js-line-number" data-line-number="15"></td>
-        <td id="LC15" class="blob-code js-file-line">        <span class="nt">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;git&quot;</span><span class="p">,</span></td>
+        <td id="LC15" class="blob-code js-file-line">        <span class="nt">&quot;name&quot;</span><span class="p">:</span> <span class="s2">&quot;Stefan Buck&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L16" class="blob-num js-line-number" data-line-number="16"></td>
-        <td id="LC16" class="blob-code js-file-line">        <span class="nt">&quot;url&quot;</span><span class="p">:</span> <span class="s2">&quot;https://github.com/stefanbuck/playground-repo&quot;</span></td>
+        <td id="LC16" class="blob-code js-file-line">        <span class="nt">&quot;email&quot;</span><span class="p">:</span> <span class="s2">&quot;dev@stefanbuck.com&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L17" class="blob-num js-line-number" data-line-number="17"></td>
-        <td id="LC17" class="blob-code js-file-line">    <span class="p">},</span></td>
+        <td id="LC17" class="blob-code js-file-line">        <span class="nt">&quot;url&quot;</span><span class="p">:</span> <span class="s2">&quot;http://stefanbuck.com&quot;</span></td>
       </tr>
       <tr>
         <td id="L18" class="blob-num js-line-number" data-line-number="18"></td>
-        <td id="LC18" class="blob-code js-file-line">    <span class="nt">&quot;keywords&quot;</span><span class="p">:</span> <span class="p">[],</span></td>
+        <td id="LC18" class="blob-code js-file-line">    <span class="p">},</span></td>
       </tr>
       <tr>
         <td id="L19" class="blob-num js-line-number" data-line-number="19"></td>
-        <td id="LC19" class="blob-code js-file-line">    <span class="nt">&quot;dependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC19" class="blob-code js-file-line">    <span class="nt">&quot;repository&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L20" class="blob-num js-line-number" data-line-number="20"></td>
-        <td id="LC20" class="blob-code js-file-line">        <span class="nt">&quot;lodash&quot;</span><span class="p">:</span> <span class="s2">&quot;2.4.1&quot;</span><span class="p">,</span></td>
+        <td id="LC20" class="blob-code js-file-line">        <span class="nt">&quot;type&quot;</span><span class="p">:</span> <span class="s2">&quot;git&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L21" class="blob-num js-line-number" data-line-number="21"></td>
-        <td id="LC21" class="blob-code js-file-line">        <span class="nt">&quot;request&quot;</span><span class="p">:</span> <span class="s2">&quot;^2.40.0&quot;</span><span class="p">,</span></td>
+        <td id="LC21" class="blob-code js-file-line">        <span class="nt">&quot;url&quot;</span><span class="p">:</span> <span class="s2">&quot;https://github.com/stefanbuck/playground-repo&quot;</span></td>
       </tr>
       <tr>
         <td id="L22" class="blob-num js-line-number" data-line-number="22"></td>
-        <td id="LC22" class="blob-code js-file-line">        <span class="nt">&quot;modernizr&quot;</span><span class="p">:</span> <span class="s2">&quot;Modernizr/Modernizr&quot;</span><span class="p">,</span></td>
+        <td id="LC22" class="blob-code js-file-line">    <span class="p">},</span></td>
       </tr>
       <tr>
         <td id="L23" class="blob-num js-line-number" data-line-number="23"></td>
-        <td id="LC23" class="blob-code js-file-line">        <span class="nt">&quot;backbone&quot;</span><span class="p">:</span> <span class="s2">&quot;jashkenas/backbone#master&quot;</span><span class="p">,</span></td>
+        <td id="LC23" class="blob-code js-file-line">    <span class="nt">&quot;keywords&quot;</span><span class="p">:</span> <span class="p">[],</span></td>
       </tr>
       <tr>
         <td id="L24" class="blob-num js-line-number" data-line-number="24"></td>
-        <td id="LC24" class="blob-code js-file-line">        <span class="nt">&quot;jquery&quot;</span><span class="p">:</span> <span class="s2">&quot;jquery/jquery#1.x-master&quot;</span><span class="p">,</span></td>
+        <td id="LC24" class="blob-code js-file-line">    <span class="nt">&quot;dependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L25" class="blob-num js-line-number" data-line-number="25"></td>
-        <td id="LC25" class="blob-code js-file-line">        <span class="nt">&quot;unknown-package-name&quot;</span><span class="p">:</span> <span class="s2">&quot;latest&quot;</span></td>
+        <td id="LC25" class="blob-code js-file-line">        <span class="nt">&quot;lodash&quot;</span><span class="p">:</span> <span class="s2">&quot;2.4.1&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L26" class="blob-num js-line-number" data-line-number="26"></td>
-        <td id="LC26" class="blob-code js-file-line">    <span class="p">},</span></td>
+        <td id="LC26" class="blob-code js-file-line">        <span class="nt">&quot;request&quot;</span><span class="p">:</span> <span class="s2">&quot;^2.40.0&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L27" class="blob-num js-line-number" data-line-number="27"></td>
-        <td id="LC27" class="blob-code js-file-line">    <span class="nt">&quot;devDependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC27" class="blob-code js-file-line">        <span class="nt">&quot;modernizr&quot;</span><span class="p">:</span> <span class="s2">&quot;Modernizr/Modernizr&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L28" class="blob-num js-line-number" data-line-number="28"></td>
-        <td id="LC28" class="blob-code js-file-line">        <span class="nt">&quot;chai&quot;</span><span class="p">:</span> <span class="s2">&quot;^1.9.1&quot;</span><span class="p">,</span></td>
+        <td id="LC28" class="blob-code js-file-line">        <span class="nt">&quot;backbone&quot;</span><span class="p">:</span> <span class="s2">&quot;jashkenas/backbone#master&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L29" class="blob-num js-line-number" data-line-number="29"></td>
-        <td id="LC29" class="blob-code js-file-line">        <span class="nt">&quot;gulp&quot;</span><span class="p">:</span> <span class="s2">&quot;^3.6.2&quot;</span></td>
+        <td id="LC29" class="blob-code js-file-line">        <span class="nt">&quot;jquery&quot;</span><span class="p">:</span> <span class="s2">&quot;jquery/jquery#1.x-master&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L30" class="blob-num js-line-number" data-line-number="30"></td>
-        <td id="LC30" class="blob-code js-file-line">    <span class="p">},</span></td>
+        <td id="LC30" class="blob-code js-file-line">        <span class="nt">&quot;unknown-package-name&quot;</span><span class="p">:</span> <span class="s2">&quot;latest&quot;</span></td>
       </tr>
       <tr>
         <td id="L31" class="blob-num js-line-number" data-line-number="31"></td>
-        <td id="LC31" class="blob-code js-file-line">    <span class="nt">&quot;optionalDependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC31" class="blob-code js-file-line">    <span class="p">},</span></td>
       </tr>
       <tr>
         <td id="L32" class="blob-num js-line-number" data-line-number="32"></td>
-        <td id="LC32" class="blob-code js-file-line">        <span class="nt">&quot;should&quot;</span><span class="p">:</span> <span class="s2">&quot;^3.3.1&quot;</span></td>
+        <td id="LC32" class="blob-code js-file-line">    <span class="nt">&quot;devDependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L33" class="blob-num js-line-number" data-line-number="33"></td>
-        <td id="LC33" class="blob-code js-file-line">    <span class="p">},</span></td>
+        <td id="LC33" class="blob-code js-file-line">        <span class="nt">&quot;chai&quot;</span><span class="p">:</span> <span class="s2">&quot;^1.9.1&quot;</span><span class="p">,</span></td>
       </tr>
       <tr>
         <td id="L34" class="blob-num js-line-number" data-line-number="34"></td>
-        <td id="LC34" class="blob-code js-file-line">    <span class="nt">&quot;peerDependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC34" class="blob-code js-file-line">        <span class="nt">&quot;gulp&quot;</span><span class="p">:</span> <span class="s2">&quot;^3.6.2&quot;</span></td>
       </tr>
       <tr>
         <td id="L35" class="blob-num js-line-number" data-line-number="35"></td>
-        <td id="LC35" class="blob-code js-file-line">        <span class="nt">&quot;yo&quot;</span><span class="p">:</span> <span class="s2">&quot;&gt;=1.0.0&quot;</span></td>
+        <td id="LC35" class="blob-code js-file-line">    <span class="p">},</span></td>
       </tr>
       <tr>
         <td id="L36" class="blob-num js-line-number" data-line-number="36"></td>
-        <td id="LC36" class="blob-code js-file-line">    <span class="p">},</span></td>
+        <td id="LC36" class="blob-code js-file-line">    <span class="nt">&quot;optionalDependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L37" class="blob-num js-line-number" data-line-number="37"></td>
-        <td id="LC37" class="blob-code js-file-line">    <span class="nt">&quot;scripts&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+        <td id="LC37" class="blob-code js-file-line">        <span class="nt">&quot;should&quot;</span><span class="p">:</span> <span class="s2">&quot;^3.3.1&quot;</span></td>
       </tr>
       <tr>
         <td id="L38" class="blob-num js-line-number" data-line-number="38"></td>
-        <td id="LC38" class="blob-code js-file-line">        <span class="nt">&quot;coveralls&quot;</span><span class="p">:</span> <span class="s2">&quot;gulp test &amp;&amp; cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js&quot;</span><span class="p">,</span></td>
+        <td id="LC38" class="blob-code js-file-line">    <span class="p">},</span></td>
       </tr>
       <tr>
         <td id="L39" class="blob-num js-line-number" data-line-number="39"></td>
-        <td id="LC39" class="blob-code js-file-line">        <span class="nt">&quot;test&quot;</span><span class="p">:</span> <span class="s2">&quot;gulp test&quot;</span></td>
+        <td id="LC39" class="blob-code js-file-line">    <span class="nt">&quot;peerDependencies&quot;</span><span class="p">:</span> <span class="p">{</span></td>
       </tr>
       <tr>
         <td id="L40" class="blob-num js-line-number" data-line-number="40"></td>
-        <td id="LC40" class="blob-code js-file-line">    <span class="p">}</span></td>
+        <td id="LC40" class="blob-code js-file-line">        <span class="nt">&quot;yo&quot;</span><span class="p">:</span> <span class="s2">&quot;&gt;=1.0.0&quot;</span></td>
       </tr>
       <tr>
         <td id="L41" class="blob-num js-line-number" data-line-number="41"></td>
-        <td id="LC41" class="blob-code js-file-line"><span class="p">}</span></td>
+        <td id="LC41" class="blob-code js-file-line">    <span class="p">},</span></td>
+      </tr>
+      <tr>
+        <td id="L42" class="blob-num js-line-number" data-line-number="42"></td>
+        <td id="LC42" class="blob-code js-file-line">    <span class="nt">&quot;scripts&quot;</span><span class="p">:</span> <span class="p">{</span></td>
+      </tr>
+      <tr>
+        <td id="L43" class="blob-num js-line-number" data-line-number="43"></td>
+        <td id="LC43" class="blob-code js-file-line">        <span class="nt">&quot;coveralls&quot;</span><span class="p">:</span> <span class="s2">&quot;gulp test &amp;&amp; cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js&quot;</span><span class="p">,</span></td>
+      </tr>
+      <tr>
+        <td id="L44" class="blob-num js-line-number" data-line-number="44"></td>
+        <td id="LC44" class="blob-code js-file-line">        <span class="nt">&quot;test&quot;</span><span class="p">:</span> <span class="s2">&quot;gulp test&quot;</span></td>
+      </tr>
+      <tr>
+        <td id="L45" class="blob-num js-line-number" data-line-number="45"></td>
+        <td id="LC45" class="blob-code js-file-line">    <span class="p">}</span></td>
+      </tr>
+      <tr>
+        <td id="L46" class="blob-num js-line-number" data-line-number="46"></td>
+        <td id="LC46" class="blob-code js-file-line"><span class="p">}</span></td>
       </tr>
 </table>
 
@@ -623,7 +850,7 @@
     </div><!-- /.wrapper -->
 
       <div class="container">
-  <div class="site-footer">
+  <div class="site-footer" role="contentinfo">
     <ul class="site-footer-links right">
       <li><a href="https://status.github.com/">Status</a></li>
       <li><a href="http://developer.github.com">API</a></li>
@@ -639,7 +866,7 @@
     </a>
 
     <ul class="site-footer-links">
-      <li>&copy; 2014 <span title="0.02215s from github-fe131-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
+      <li>&copy; 2014 <span title="0.05185s from github-fe122-cp1-prd.iad.github.net">GitHub</span>, Inc.</li>
         <li><a href="/site/terms">Terms</a></li>
         <li><a href="/site/privacy">Privacy</a></li>
         <li><a href="/security">Security</a></li>
@@ -675,10 +902,10 @@
     </div>
 
 
-      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-0c1b00f7935ae85624f5fc5d40d52d60febf92b4.js" type="text/javascript"></script>
-      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-5ecb6588735013bbe8940399e4154ceea28b35f9.js" type="text/javascript"></script>
-
-
+      <script crossorigin="anonymous" src="https://assets-cdn.github.com/assets/frameworks-f4749195ce218608caf72b3ddefff5f580445386f2529c60e027cd18d1db0cb5.js" type="text/javascript"></script>
+      <script async="async" crossorigin="anonymous" src="https://assets-cdn.github.com/assets/github-56901a1e60b184d90b134d3f30a8700dee7e5d313a3a70e28f6adb239d7d8797.js" type="text/javascript"></script>
+      
+      
         <script async src="https://www.google-analytics.com/analytics.js"></script>
   </body>
 </html>

--- a/test/test_manifest_package_local.js
+++ b/test/test_manifest_package_local.js
@@ -53,7 +53,7 @@ describe('manifest', function() {
       });
 
       it('check link replacement', function() {
-        $('a.github-linker').length.should.equal(11);
+        $('a.github-linker').length.should.equal(14);
       });
 
       it('link https://github.com/lodash/lodash', function() {
@@ -128,10 +128,29 @@ describe('manifest', function() {
         item.el.hasClass('tooltipped').should.be.false;
       });
 
+      it('link directories', function() {
+        var directories = $('span.nt:contains("directories")').closest('tr');
+        var main = directories.next().find('.github-linker').attr('href');
+        var bin = directories.next().next().find('.github-linker').attr('href');
+
+        (!!main).should.equal(true);
+        main.should.equal('./main');
+        (!!bin).should.equal(true);
+        bin.should.equal('./bin');
+      });
+
       it('entry file', function() {
-        var mainFile = $('span.nt:contains("main")').parent().find('.github-linker').attr('href');
+        var mainFile = $('span.nt:contains("main")').parent()
+                       .find('.s2:contains("index.js")').parent().attr('href');
         (!!mainFile).should.equal(true);
         mainFile.should.equal('index.js');
+      });
+
+      it('bin file', function() {
+        var binFile = $('span.nt:contains("bin")').parent()
+                       .find('.s2:contains("./index.js")').parent().attr('href');
+        (!!binFile).should.equal(true);
+        binFile.should.equal('./index.js');
       });
     });
   });


### PR DESCRIPTION
Before, if there is a directory called 'main', it will be treated as 'main' field. For example:

```
"directories": {
   "main": "./main",
   "bin": "./bin"
 },
 "bin": "./index.js",
 "main": "index.js",
```

The html structure of `"main": "index.js"` and `"main": "./main",` are the same. So with 'bin' field and 'bin' directory.

With adding links to 'directories' field before adding links to 'main' and 'bin' fields, we can distingush directories from the fields of the same name.
