### PR TITLE
Fix wrong github repository dependency on OctoLinker/resolver

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ So please, **open new issues only** [there](https://github.com/octo-linker/chrom
 [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-url]][daviddm-image] [![Coverage Status][coveralls-image]][coveralls-url]
 
 
-This browserify friendly npm module contains everything what the Octo-Linker needs to work. Currently the core is only used by the Octo-Linker [Chrome Extension](https://github.com/octo-linker/chrome-extension). It would be possible to create other Octo-Linker extensions for another browser as well. But this is currently out of scope. By the way, contributes are welcome. Get in touch with me!
+This browserify friendly npm module contains everything that the Octo-Linker needs to work. Currently the core is only used by the Octo-Linker [Chrome Extension](https://github.com/octo-linker/chrome-extension). It would be possible to create other Octo-Linker extensions for another browser as well. But this is currently out of scope. By the way, contributes are welcome. Get in touch with me!
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "async": "^1.4.2",
     "builtins": "^1.0.2",
     "github-injection": "^0.1.0",
-    "octo-linker-resolver": "octo-linker/resolver",
+    "octo-resolver": "OctoLinker/resolver",
     "jquery": "^2.1.1",
     "lodash": "2.4.1"
   },


### PR DESCRIPTION
The dependency seems to refer to the wrong repo.
I didn't find the `octo-resolver` on npm, it would be beautiful if could publish it.

Since I'm not a native english speaker, I'm not 100% sure on the typo :smiley_cat: 
